### PR TITLE
moved foundation-menu include above dropdown to fix issue where dropdowns stay open with flexbox mode enabled

### DIFF
--- a/scss/app.scss
+++ b/scss/app.scss
@@ -18,14 +18,14 @@
 @include foundation-button-group;
 @include foundation-callout;
 @include foundation-close-button;
+@include foundation-menu;
+@include foundation-menu-icon;
 @include foundation-drilldown-menu;
 @include foundation-dropdown;
 @include foundation-dropdown-menu;
 @include foundation-flex-video;
 @include foundation-label;
 @include foundation-media-object;
-@include foundation-menu;
-@include foundation-menu-icon;
 @include foundation-off-canvas;
 @include foundation-orbit;
 @include foundation-pagination;


### PR DESCRIPTION
Fix for [this issue](https://github.com/zurb/foundation-sites/issues/8305#issuecomment-191393555).