### PR TITLE
Added missing normalize package to bower config.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,8 @@
   "homepage": "http://foundation.zurb.com",
   "dependencies": {
     "foundation-sites": "~6.3.0",
-    "motion-ui": "~1.2.2"
+    "motion-ui": "~1.2.2",
+    "normalize.scss": "~6.0.0"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
# Issue
A requirement that "normalize.scss" is available through bower packages is set in the [gulp.js](https://github.com/zurb/foundation-sites-template/blob/master/gulpfile.js) script via the sassPath variable.
```js
var sassPaths = [
  'bower_components/normalize.scss/sass',
  'bower_components/foundation-sites/scss',
  'bower_components/motion-ui/src'
];
```

As of current, bower.json does not explicitly list the "normalize.scss" package as a dependency.   Of which, when running ```gulp```, produces a style sheet lacking the proper "normalized" base styles. 

# Fix 
Explicitly added "normailze.scss" to [gulp.js](https://github.com/zurb/foundation-sites-template/blob/master/gulpfile.js)

```json
  "dependencies": {
    "foundation-sites": "~6.3.0",
    "motion-ui": "~1.2.2",
    "normalize.scss": "~6.0.0"
  }
```