### PR TITLE
fix: enable back flex utilities

### DIFF
--- a/scss/app.scss
+++ b/scss/app.scss
@@ -55,7 +55,7 @@
 
 // Helpers
 @include foundation-float-classes;
-// @include foundation-flex-classes;
+@include foundation-flex-classes;
 @include foundation-visibility-classes;
 // @include foundation-prototype-classes;
 


### PR DESCRIPTION
Flex utilities should be enabled by default in flex mode.

Closes https://github.com/zurb/foundation-sites/issues/11623
Related to https://github.com/zurb/foundation-zurb-template/pull/93